### PR TITLE
Use full-width grid layout for tab navigation

### DIFF
--- a/src/components/layout/TabNavigation.jsx
+++ b/src/components/layout/TabNavigation.jsx
@@ -19,14 +19,14 @@ export default function TabNavigation() {
   }
 
   return (
-    <div 
-      className="fixed bottom-0 left-0 right-0 w-full z-50"
+    <div
+      className="fixed bottom-0 left-0 w-screen z-50"
       style={{
         paddingBottom: 'env(safe-area-inset-bottom, 0px)'
       }}
     >
       <div className="w-full bg-slate-900/95 backdrop-blur-lg border-t border-white/10">
-        <div className="flex w-full">
+        <div className="grid grid-cols-4 w-full">
           {TABS.map((tab) => (
             <button
               key={tab.id}
@@ -35,8 +35,8 @@ export default function TabNavigation() {
                 flex-1 flex flex-col items-center gap-1 py-3 px-2 text-xs font-semibold
                 transition-all duration-300 relative uppercase tracking-wide
                 min-h-[60px] min-w-0
-                ${currentTab === tab.id 
-                  ? 'text-yellow-400' 
+                ${currentTab === tab.id
+                  ? 'text-yellow-400'
                   : 'text-gray-400 hover:text-gray-200 active:text-gray-100'
                 }
               `}


### PR DESCRIPTION
## Summary
- ensure TabNavigation grid spans full width so tabs render in a single row
- keep each tab button flex-1 for consistent sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a6255e4988832598791bcd1a42ecb2